### PR TITLE
Speed up rendering from asdf

### DIFF
--- a/deepixel-test.py
+++ b/deepixel-test.py
@@ -11,6 +11,7 @@ import pybrot
 
 import asdf
 import sys
+import numpy as np
 
 # Arguments: <path_asdf> <path_output>
 path_asdf = ''
@@ -23,25 +24,54 @@ except (IndexError, ValueError):
     print('Usage: <program> <path_to_input_asdf> <path_to_output_png>')
     exit(1)
 
-af = asdf.open(path_asdf)
-data = [[float(i) for i in j] for j in af.tree['data-raw']]
-maxIteration = int(af.tree['debug']['original-arguments']['max-Iter'])
-samples = [len(data[0]), len(data)]
+print('Open file %s' % path_asdf, end='...   ', flush=True)
+af = asdf.open(path_asdf, copy_arrays=True)
+print('done')
 
-print('data collected')
+print('Read file', end='...                ', flush=True)
+data = np.array(af.tree['data-raw'])
+maxIteration = int(af.tree['debug']['original-arguments']['max-Iter'])
+minIteration = data.min()
+samples = [len(data[0]), len(data)]
+print('done')
+print('  maxIteration: %d' % maxIteration)
+print('  minIteration: %d' % minIteration)
+print('  samples: %dx%d (%.2fMP)' % (samples[0], samples[1], samples[0] * samples[1] / 1000000.0))
 
 # set non-escaping to 0
-data = [[pybrot.image.value_replace(value, maxIteration, 0) for value in row] for row in data]
+print('Zero unescaped samples', end='...   ', flush=True)
+zero = np.array([value for value in range(maxIteration+1)])
+zero[-1] = minIteration
+data = zero[data]
+print('done')
+
 # normalize
-data = pybrot.image.normalize(data)
-# intensity mapping
-data = [[pybrot.image.color_sigmoid(pybrot.image.color_log(value, f=256), alpha=0.8) for value in row] for row in data]
+print('Normalize samples', end='...        ', flush=True)
+maxIteration = data.max()
+lookup = list(range(minIteration, maxIteration+1))
+lookup = pybrot.image.normalize(lookup, minimum=minIteration, maximum=maxIteration)
+print('done')
+print('  maxIteration (true): %d' % maxIteration)
 
-# colormap
-data = pybrot.image.colormap(data, max_color=255, name='viridis')
-data = pybrot.image.flatten(data)
+# remap
+print('Remap samples', end='...            ', flush=True)
+lookup = [pybrot.image.color_sigmoid(pybrot.image.color_log(value, f=maxIteration), alpha=0.2) for value in lookup]
+print('done')
 
-# export
-pybrot.image.write_raw_png(data, path_output, samples, greyscale=False)
+# colormap (Set name to None for greyscale mapping)
+print('Apply color map', end='...          ', flush=True)
+lookup = pybrot.image.colormap(lookup, bit_depth=8, name='plasma')
+print('done')
 
-print('done - file written to: '+path_output)
+# apply lookup table to data
+print('Apply lookup table', end='...       ', flush=True)
+lookup = np.array(lookup)
+data = lookup[data-minIteration]
+if(isinstance(lookup[0], np.ndarray)):
+    data = data.reshape([samples[1], samples[0]*3])
+print('done')
+
+# export image
+print('Export image to %s' % path_output, end='...   ', flush=True)
+pybrot.image.write_raw_png(data, path_output, samples, greyscale=(not isinstance(lookup[0], np.ndarray)))
+print('done')

--- a/deepixel-test.py
+++ b/deepixel-test.py
@@ -40,33 +40,32 @@ print('  samples: %dx%d (%.2fMP)' % (samples[0], samples[1], samples[0] * sample
 
 # set non-escaping to 0
 print('Zero unescaped samples', end='...   ', flush=True)
-zero = np.array([value for value in range(maxIteration+1)])
+zero = np.array(range(maxIteration+1))
 zero[-1] = minIteration
+# apply lookup table to data
+# same as [zero[value] for value in data]
 data = zero[data]
 print('done')
 
-# normalize
-print('Normalize samples', end='...        ', flush=True)
+# remap
+print('Remap samples', end='...            ', flush=True)
 maxIteration = data.max()
-lookup = list(range(minIteration, maxIteration+1))
-lookup = pybrot.image.normalize(lookup, minimum=minIteration, maximum=maxIteration)
+lookup = np.linspace(0, 1, maxIteration-minIteration+1)
+lookup = [pybrot.image.color_sigmoid(pybrot.image.color_log(value, f=maxIteration), alpha=0.2) for value in lookup]
 print('done')
 print('  maxIteration (true): %d' % maxIteration)
 
-# remap
-print('Remap samples', end='...            ', flush=True)
-lookup = [pybrot.image.color_sigmoid(pybrot.image.color_log(value, f=maxIteration), alpha=0.2) for value in lookup]
-print('done')
-
 # colormap (Set name to None for greyscale mapping)
 print('Apply color map', end='...          ', flush=True)
-lookup = pybrot.image.colormap(lookup, bit_depth=8, name='plasma')
+lookup = np.array(pybrot.image.colormap(lookup, bit_depth=8, name='plasma'))
 print('done')
 
 # apply lookup table to data
 print('Apply lookup table', end='...       ', flush=True)
-lookup = np.array(lookup)
+# apply lookup table to data
+# same as [lookup[value] for value in data]
 data = lookup[data-minIteration]
+# flatten rgb value tuples in data
 if(isinstance(lookup[0], np.ndarray)):
     data = data.reshape([samples[1], samples[0]*3])
 print('done')

--- a/pybrot/image.py
+++ b/pybrot/image.py
@@ -30,13 +30,6 @@ class Image:
 
 # --- Low Level Functions --- #
 
-
-def value_replace(value, check, new=0):
-    if value == check:
-        return new
-    return value
-
-
 def color_log(value, f=1024):
     return math.log(1 + value*f, 1 + f)
 
@@ -46,31 +39,24 @@ def color_sigmoid(value, alpha=0.2):
     return (sig - 0.5) * 1.0 / (1.0 - 2.0 / (1.0 + math.pow(math.e, 0.5 / alpha))) + 0.5
 
 
-def colormap(data, max_color, name=None):
+def colormap(data, bit_depth, name=None):
     # Color mapping
     # See https://matplotlib.org/gallery/color/colormap_reference.html for stock colormaps.
     # Set to name to None for bw rendering
-    # Apply colormap & Convert color data to suitable array for pypng output.
-    return [[[int(k*max_color) for k in j] for j in i] for i in cm.get_cmap(name)(data)]
+    if (name):
+        colormap = cm.ScalarMappable(cmap=name).to_rgba(data, norm=False)
+        return [[int(value * (2**bit_depth-1)) for value in rgba[:-1]] for rgba in colormap]
+    else:
+        return colormap_grey(data, bit_depth)
 
 
 def colormap_grey(data, max_color):
-    return [[int(j*max_color) for j in i] for i in data]
+    return [int(value * (2**bit_depth-1)) for value in data]
 
 
-def normalize(data):
-    maximum = max([max(i) for i in data])
-    minimum = min([min(i) for i in data])
-    return [[(j-minimum)/(maximum-minimum) for j in i] for i in data]
+def normalize(data, minimum, maximum):
+    return [(value-minimum)/(maximum-minimum) for value in data]
 
-
-def normalize_reference(data, reference):
-    # usually: reference = max_iteration
-    return [[i/reference for i in row] for row in data]
-
-
-def flatten(data):
-    return [[i for rgba in row for i in rgba[:-1]] for row in data]
 
 # --- Export Functions --- #
 

--- a/pybrot/image.py
+++ b/pybrot/image.py
@@ -50,7 +50,7 @@ def colormap(data, bit_depth, name=None):
         return colormap_grey(data, bit_depth)
 
 
-def colormap_grey(data, max_color):
+def colormap_grey(data, bit_depth):
     return [int(value * (2**bit_depth-1)) for value in data]
 
 

--- a/pybrot/image.py
+++ b/pybrot/image.py
@@ -54,10 +54,6 @@ def colormap_grey(data, bit_depth):
     return [int(value * (2**bit_depth-1)) for value in data]
 
 
-def normalize(data, minimum, maximum):
-    return [(value-minimum)/(maximum-minimum) for value in data]
-
-
 # --- Export Functions --- #
 
 


### PR DESCRIPTION
Implement color maps via a lookup table.

Use built-in numpy functions instead of min() and max(), and use numpy to apply lookup tables.

Rewrite incremental output to look nicer and provide metadata.

Autodetect greyscale output if the user sets colormap to None.